### PR TITLE
Add configurable local inference support with Docker container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ MODEL_ID=shipping-label-k3hzg/4
 # Lower values detect more labels but may include false positives
 CONFIDENCE_THRESH=0.04
 
+# Inference API URL Configuration
+# For cloud inference (default):
+INFERENCE_API_URL=https://serverless.roboflow.com/
+# For local inference (when using docker-compose):
+# INFERENCE_API_URL=http://inference-server:9001
+# For local inference (when running standalone):
+# INFERENCE_API_URL=http://localhost:9001
+
 # Logging Configuration
 # Set the logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,48 @@ The application requires a `.env` file with:
 ROBOFLOW_API_KEY=your_api_key_here
 ```
 
+### Inference Configuration
+
+LineCook supports both cloud-based and local inference:
+
+**Cloud Inference (Default):**
+```bash
+INFERENCE_API_URL=https://serverless.roboflow.com/
+```
+
+**Local Inference with Docker Compose:**
+```bash
+# Uses the local inference container in the stack
+INFERENCE_API_URL=http://inference-server:9001
+```
+
+**Local Inference (Standalone):**
+```bash
+# For running against a local inference server on host
+INFERENCE_API_URL=http://localhost:9001
+```
+
+### Running Local Inference
+
+To use local inference with the provided Docker Compose stack:
+
+1. **Start the full stack** (includes local inference server):
+   ```bash
+   docker-compose up
+   ```
+
+2. **Start only the inference server** for standalone use:
+   ```bash
+   docker run -p 9001:9001 -e ROBOFLOW_API_KEY=your_key roboflow/roboflow-inference-server-cpu
+   ```
+
+### Benefits of Local Inference
+
+- **Faster response times** (no network latency to cloud)
+- **Data privacy** (images processed locally)
+- **Offline capability** (after initial model download)
+- **Cost reduction** (no per-inference API charges)
+
 ## Architecture
 
 ### Core Components

--- a/README.md
+++ b/README.md
@@ -28,7 +28,33 @@ This is designed to solve a super narrow problem - when using a label printer yo
    ROBOFLOW_API_KEY=your_api_key_here
    ```
 
-  __Note__: see `.env.example` for more configuration options
+   __Note__: see `.env.example` for more configuration options
+
+### Inference Configuration
+
+LineCook supports both cloud-based and local inference. By default, it uses Roboflow's cloud API, but you can run inference locally for better performance and privacy.
+
+#### Cloud Inference (Default)
+Uses Roboflow's cloud API (requires internet connection):
+```env
+INFERENCE_API_URL=https://serverless.roboflow.com/
+```
+
+#### Local Inference 
+For local processing with Docker Compose (recommended for production):
+```env
+INFERENCE_API_URL=http://inference-server:9001
+```
+
+For standalone local inference server:
+```env  
+INFERENCE_API_URL=http://localhost:9001
+```
+
+To run a standalone local inference server:
+```bash
+docker run -p 9001:9001 -e ROBOFLOW_API_KEY=your_key roboflow/roboflow-inference-server-cpu
+```
 
 4. **Docker setup**:
     Getting CUPS working in docker can be a bit finicky. The commented lines in `docker-compose.yml` work well for me on an Ubuntu host (with CUPS setup). In general, mounting cups.sock seems to be the suggested approach here. Feel free to share alternatives if they work for you. ie. I have not had any luck (nor have I tried much yet) running this on a MacOS host.. 

--- a/config.py
+++ b/config.py
@@ -90,6 +90,12 @@ class Settings(BaseSettings):
         default=30,
         description="API request timeout in seconds"
     )
+    
+    # Inference configuration
+    inference_api_url: str = Field(
+        default="https://serverless.roboflow.com/",
+        description="Roboflow inference API URL. Use 'https://serverless.roboflow.com/' for cloud inference or 'http://localhost:9001' for local inference server"
+    )
 
 
 def setup_logging(settings: Settings) -> logging.Logger:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,22 @@
 services:
+  # Local Roboflow inference server
+  inference-server:
+    image: roboflow/roboflow-inference-server-cpu:latest
+    container_name: linecook-inference
+    ports:
+      - "9001:9001"
+    environment:
+      - ROBOFLOW_API_KEY=${ROBOFLOW_API_KEY}
+    volumes:
+      - inference-cache:/tmp/cache
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9001/health"] 
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
   linecook-api:
 #    image: ghcr.io/johnfodero/linecook:latest
     build:
@@ -12,8 +30,12 @@ services:
       - ROBOFLOW_API_KEY=${ROBOFLOW_API_KEY}
       - MODEL_ID=${MODEL_ID:-shipping-label-k3hzg/4}
       - CONFIDENCE_THRESH=${CONFIDENCE_THRESH:-0.04}
+      - INFERENCE_API_URL=${INFERENCE_API_URL:-http://inference-server:9001}
     env_file:
       - .env
+    depends_on:
+      inference-server:
+        condition: service_healthy
     restart: unless-stopped
     # uncomment when running on a linux host 
     # volumes:
@@ -25,3 +47,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+volumes:
+  inference-cache:

--- a/services/inference.py
+++ b/services/inference.py
@@ -44,13 +44,13 @@ class InferenceService:
             confidence_threshold=confidence_threshold
         )
         
-        # Initialize client with secure API key handling
+        # Initialize client with configurable API URL
         self.client = InferenceHTTPClient(
-            api_url="https://serverless.roboflow.com/",
+            api_url=settings.inference_api_url,
             api_key=api_key
         )
         
-        logger.info(f"Initialized inference service with model {model_id}")
+        logger.info(f"Initialized inference service with model {model_id} using API URL: {settings.inference_api_url}")
     
     def infer_image(self, image_input: Union[str, Path, Image.Image]) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- Add configurable local inference support to enable running Roboflow inference locally via Docker
- Enable users to choose between cloud-based (default) and local inference for improved performance and privacy

## Changes
- Added `INFERENCE_API_URL` configuration option with support for cloud and local endpoints
- Integrated local Roboflow inference server into Docker Compose stack with health checks
- Updated inference service to use configurable API URL instead of hardcoded cloud endpoint
- Enhanced documentation with local inference setup instructions and benefits

## Benefits of Local Inference
- Faster response times (no network latency)
- Data privacy (images processed locally)
- Offline capability (after initial model download)
- Cost reduction (no per-inference API charges)

## Configuration Options
- **Cloud (default)**: `INFERENCE_API_URL=https://serverless.roboflow.com/`
- **Local with Docker Compose**: `INFERENCE_API_URL=http://inference-server:9001`
- **Local standalone**: `INFERENCE_API_URL=http://localhost:9001`